### PR TITLE
Add client directives to UI components

### DIFF
--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -1,3 +1,5 @@
+'use client'; // Enables client-side rendering in Next.js
+
 import React from 'react';
 import { cn } from '../utils/cn';
 import { Button } from './Button';
@@ -28,15 +30,11 @@ export interface AppShellProps {
  * optional header content. The shell respects user preferences such as
  * reduced motion and supports dark mode via Tailwind's class toggles.
  */
-export const AppShell: React.FC<AppShellProps> = ({
-  children,
-  navItems = [],
-  headerContent,
-}) => {
+export const AppShell: React.FC<AppShellProps> = ({ children, navItems = [], headerContent }) => {
   return (
     <div className="flex min-h-screen bg-background text-foreground">
       {/* Sidebar: hidden on small screens */}
-      <aside className={cn('hidden', 'md:flex', 'w-64', 'border-r', 'bg-muted', 'p-4', 'flex-col')}>\
+      <aside className={cn('hidden', 'md:flex', 'w-64', 'border-r', 'bg-muted', 'p-4', 'flex-col')}>
         <h1 className="mb-4 text-lg font-semibold">Menu</h1>
         <nav className="space-y-2">
           {navItems.map(item => (

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,3 +1,5 @@
+'use client'; // Required for interactive button behaviors
+
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cn } from '../utils/cn';

--- a/packages/ui/src/components/ThemeProvider.tsx
+++ b/packages/ui/src/components/ThemeProvider.tsx
@@ -1,3 +1,5 @@
+'use client'; // Enables dynamic theme changes on the client
+
 import React, { createContext, useEffect, useState, useContext } from 'react';
 
 interface ThemeContextValue {
@@ -13,16 +15,12 @@ const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
  * to the `<html>` element. The default theme respects the user's system
  * preference via the `prefers-color-scheme` media query.
  */
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window === 'undefined') return 'light';
     const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
     if (stored) return stored;
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   });
 
   useEffect(() => {
@@ -36,11 +34,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
     setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
   };
 
-  return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
 };
 
 export function useTheme(): ThemeContextValue {

--- a/packages/ui/src/components/ToastManager.tsx
+++ b/packages/ui/src/components/ToastManager.tsx
@@ -1,3 +1,5 @@
+'use client'; // Required for interactive toast notifications
+
 import React, { createContext, useContext, useState } from 'react';
 import { cn } from '../utils/cn';
 


### PR DESCRIPTION
## Summary
- ensure AppShell, Button, ThemeProvider, and ToastManager are treated as Next.js client components
- remove stray escape in AppShell sidebar markup

## Testing
- `pnpm exec prettier packages/ui/src/components/AppShell.tsx packages/ui/src/components/ThemeProvider.tsx --write`
- `pnpm exec eslint packages/ui/src/components/AppShell.tsx packages/ui/src/components/ThemeProvider.tsx packages/ui/src/components/Button.tsx packages/ui/src/components/ToastManager.tsx --ext .ts,.tsx`
- `pnpm test --filter @acme/ui`


------
https://chatgpt.com/codex/tasks/task_e_68acd496dc6c8320bc41df3d31300aee