### PR TITLE
Handle Prisma errors in project router

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,30 +10,31 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "next": "^14.2.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@tanstack/react-query": "^4.36.1",
-    "@trpc/client": "^10.45.0",
-    "@trpc/server": "^10.45.0",
-    "@trpc/react-query": "^10.45.0",
+    "@acme/config": "workspace:^1.0.0",
     "@acme/db": "workspace:^1.0.0",
     "@acme/ui": "workspace:^1.0.0",
-    "@acme/config": "workspace:^1.0.0",
-    "next-auth": "^4.24.11",
     "@next-auth/prisma-adapter": "^1.0.7",
-    "zod": "^3.23.8",
-    "clsx": "^2.0.0"
+    "@tanstack/react-query": "^4.36.1",
+    "@trpc/client": "^10.45.0",
+    "@trpc/react-query": "^10.45.0",
+    "@trpc/server": "^10.45.0",
+    "clsx": "^2.0.0",
+    "next": "^14.2.1",
+    "next-auth": "^4.24.11",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "superjson": "^2.2.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/react": "^18.2.21",
+    "@testing-library/react": "^14.1.2",
     "@types/node": "^20.12.7",
+    "@types/react": "^18.2.21",
     "autoprefixer": "^10.4.16",
+    "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
-    "vitest": "^1.6.0",
-    "@testing-library/react": "^14.1.2",
-    "jest-environment-jsdom": "^29.7.0"
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/web/src/server/routers/project.test.ts
+++ b/apps/web/src/server/routers/project.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { projectRouter } from './project';
+import type { Context } from '../context';
+
+// Helper to build a caller with injected prisma stub and authenticated session
+function createCaller(prismaMock: Pick<Context['prisma'], 'project'>) {
+  return projectRouter.createCaller({
+    prisma: prismaMock as unknown as Context['prisma'],
+    session: { user: { id: 'user-1' } },
+  });
+}
+
+describe('project router error handling', () => {
+  it('maps prisma errors to INTERNAL_SERVER_ERROR on create', async () => {
+    const error = Object.assign(new Error('fail'), { code: 'P2002' });
+    const prismaMock = { project: { create: vi.fn().mockRejectedValue(error) } };
+    const caller = createCaller(prismaMock);
+
+    await expect(caller.create({ name: 'n', description: 'd' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+
+  it('translates P2025 to NOT_FOUND on delete', async () => {
+    const error = Object.assign(new Error('missing'), { code: 'P2025' });
+    const prismaMock = { project: { update: vi.fn().mockRejectedValue(error) } };
+    const caller = createCaller(prismaMock);
+
+    await expect(caller.delete({ id: '123' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+});

--- a/apps/web/src/server/routers/project.ts
+++ b/apps/web/src/server/routers/project.ts
@@ -1,6 +1,7 @@
 import { router, publicProcedure, protectedProcedure } from '../trpc';
 import { z } from 'zod';
 import { createProjectSchema } from '@acme/db/schemas';
+import { TRPCError } from '@trpc/server';
 
 /**
  * Router handling project management operations. The procedures defined here
@@ -21,11 +22,19 @@ export const projectRouter = router({
   /**
    * Create a new project. Only authenticated users may perform this action.
    */
-  create: protectedProcedure
-    .input(createProjectSchema)
-    .mutation(async ({ ctx, input }) => {
-      return ctx.prisma.project.create({ data: input });
-    }),
+  create: protectedProcedure.input(createProjectSchema).mutation(async ({ ctx, input }) => {
+    try {
+      // Delegate creation to Prisma while propagating typed errors
+      return await ctx.prisma.project.create({ data: input });
+    } catch (error) {
+      console.error('Failed to create project', error);
+      // Normalize Prisma exceptions into tRPC errors for clients
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        cause: error as Error,
+      });
+    }
+  }),
   /**
    * Soft delete a project by setting the `deletedAt` timestamp. This keeps
    * historical data intact for audit purposes.
@@ -33,25 +42,37 @@ export const projectRouter = router({
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.prisma.project.update({
-        where: { id: input.id },
-        data: { deletedAt: new Date() },
-      });
+      try {
+        // Soft delete by timestamp to retain historical data
+        return await ctx.prisma.project.update({
+          where: { id: input.id },
+          data: { deletedAt: new Date() },
+        });
+      } catch (error) {
+        console.error('Failed to delete project', error);
+        if (error instanceof Error && (error as { code?: string }).code === 'P2025') {
+          // P2025 signals missing record; surface a 404
+          throw new TRPCError({ code: 'NOT_FOUND', cause: error });
+        }
+        // Unknown failures surface as 500s
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          cause: error as Error,
+        });
+      }
     }),
   /**
    * Retrieve a single project by its ID. Returns `null` if not found.
    */
-  get: publicProcedure
-    .input(z.object({ id: z.string() }))
-    .query(async ({ ctx, input }) => {
-      return ctx.prisma.project.findUnique({
-        where: { id: input.id },
-        include: {
-          equipment: true,
-          documents: true,
-          tasks: true,
-          estimates: true,
-        },
-      });
-    }),
+  get: publicProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
+    return ctx.prisma.project.findUnique({
+      where: { id: input.id },
+      include: {
+        equipment: true,
+        documents: true,
+        tasks: true,
+        estimates: true,
+      },
+    });
+  }),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      superjson:
+        specifier: ^2.2.2
+        version: 2.2.2
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1133,6 +1136,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1775,6 +1782,10 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -2615,6 +2626,10 @@ packages:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superjson@2.2.2:
+    resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
+    engines: {node: '>=16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3800,6 +3815,10 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4613,6 +4632,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-what@4.1.16: {}
 
   isarray@2.0.5: {}
 
@@ -5572,6 +5593,10 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
+
+  superjson@2.2.2:
+    dependencies:
+      copy-anything: 3.0.5
 
   supports-color@7.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- catch and translate Prisma errors in project create/delete APIs
- add tests for project router error handling
- install missing superjson dependency

## Testing
- `pnpm test`
- `pnpm --filter @acme/web lint` *(fails: prettier/prettier errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68acd4b04a74832088eb72364205179f