### PR TITLE
feat: add semantic search service

### DIFF
--- a/apps/web/src/server/routers/index.ts
+++ b/apps/web/src/server/routers/index.ts
@@ -1,5 +1,6 @@
 import { router } from '../trpc';
 import { projectRouter } from './project';
+import { searchRouter } from './search';
 
 /**
  * Root application router combining all domain routers. Additional routers
@@ -7,6 +8,7 @@ import { projectRouter } from './project';
  */
 export const appRouter = router({
   project: projectRouter,
+  search: searchRouter,
   // equipment: equipmentRouter,
   // task: taskRouter,
   // document: documentRouter,

--- a/apps/web/src/server/routers/search.ts
+++ b/apps/web/src/server/routers/search.ts
@@ -1,0 +1,22 @@
+import { router, publicProcedure } from '../trpc';
+import { z } from 'zod';
+import { semanticSearch } from '@acme/ai';
+
+/**
+ * Router exposing semantic document search based on vector similarity.
+ */
+export const searchRouter = router({
+  /**
+   * Perform a semantic search over stored document embeddings.
+   */
+  semantic: publicProcedure
+    .input(
+      z.object({
+        query: z.string().min(1, 'query is required'),
+        limit: z.number().int().min(1).max(20).optional(),
+      }),
+    )
+    .query(async ({ input }) => {
+      return semanticSearch(input.query, input.limit);
+    }),
+});

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@acme/ai",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "lint": "eslint . --ext .ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "openai": "^4.0.0",
+    "@acme/config": "workspace:*",
+    "@acme/db": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/ai/src/__tests__/embedding.test.ts
+++ b/packages/ai/src/__tests__/embedding.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock configuration module to supply API key without loading real env parser.
+vi.mock('@acme/config', () => ({ env: { OPENAI_API_KEY: 'test-key' } }));
+
+// Mock database layer to avoid Prisma initialization during tests.
+vi.mock('@acme/db', () => ({ execute: vi.fn() }));
+
+// Mock OpenAI client to avoid network calls.
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    embeddings: {
+      create: () => Promise.resolve({ data: [{ embedding: [1, 2, 3] }] }),
+    },
+  })),
+}));
+
+import { generateEmbedding } from '../embedding';
+
+describe('generateEmbedding', () => {
+  it('returns an embedding vector', async () => {
+    const vec = await generateEmbedding('hello');
+    expect(vec).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/ai/src/embedding.ts
+++ b/packages/ai/src/embedding.ts
@@ -1,0 +1,64 @@
+import OpenAI from 'openai';
+import { env } from '@acme/config';
+import { execute } from '@acme/db';
+
+// Create a single OpenAI client instance. This avoids reinitialization
+// overhead in serverless environments.
+const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+
+/**
+ * Generate an embedding vector for the provided text.
+ *
+ * @param text - Input text to encode.
+ * @param abortSignal - Optional abort signal for cancellation.
+ * @returns Array of numbers representing the embedding vector.
+ */
+export async function generateEmbedding(
+  text: string,
+  abortSignal?: AbortSignal,
+): Promise<number[]> {
+  const response = await client.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text,
+    signal: abortSignal,
+  });
+  return response.data[0]?.embedding ?? [];
+}
+
+/**
+ * Encode and persist a document's embedding in the database.
+ * Existing embeddings for the document are updated.
+ */
+export async function storeDocumentEmbedding(
+  documentId: string,
+  text: string,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  const vector = await generateEmbedding(text, abortSignal);
+  await execute((db) =>
+    db.embedding.upsert({
+      where: { documentId },
+      update: { vector },
+      create: { documentId, vector },
+    }),
+  );
+}
+
+/**
+ * Perform a semantic search against stored document embeddings.
+ * Returns matching embeddings including their associated documents.
+ */
+export async function semanticSearch(
+  query: string,
+  limit = 5,
+  abortSignal?: AbortSignal,
+) {
+  const vector = await generateEmbedding(query, abortSignal);
+  return execute((db) =>
+    db.embedding.findMany({
+      take: limit,
+      orderBy: { vector: { _cosine: vector } },
+      include: { document: true },
+    }),
+  );
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,0 +1,1 @@
+export * from './embedding';

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/config/src/__tests__/env.test.ts
+++ b/packages/config/src/__tests__/env.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Ensure each test gets a fresh module instance
+vi.resetModules();
+
+describe('env schema', () => {
+  it('parses required variables including API key', async () => {
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
+    process.env.NEXTAUTH_SECRET = '12345678901234567890123456789012';
+    process.env.NEXTAUTH_URL = 'http://localhost:3000';
+    process.env.OPENAI_API_KEY = 'test-key';
+    const { env } = await import('../env');
+    expect(env.OPENAI_API_KEY).toBe('test-key');
+  });
+});

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -15,6 +15,8 @@ const envSchema = z.object({
   NEXTAUTH_SECRET: z.string().min(32, 'NEXTAUTH_SECRET should be at least 32 characters long'),
   // Public URL where the Next.js application is hosted.
   NEXTAUTH_URL: z.string().url(),
+  // API key for OpenAI or compatible embedding provider.
+  OPENAI_API_KEY: z.string().min(1, 'OPENAI_API_KEY is required'),
   // S3-compatible object storage configuration. Optional if file uploads are disabled.
   S3_ENDPOINT: z.string().url().optional(),
   S3_ACCESS_KEY: z.string().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,25 @@ importers:
         specifier: ^1.45.0
         version: 1.55.0
 
+  packages/ai:
+    dependencies:
+      '@acme/config':
+        specifier: workspace:*
+        version: link:../config
+      '@acme/db':
+        specifier: workspace:*
+        version: link:../db
+      openai:
+        specifier: ^4.0.0
+        version: 4.104.0(ws@8.18.3)(zod@3.25.76)
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.2
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.11)(jsdom@20.0.3)
+
   packages/config:
     dependencies:
       '@opentelemetry/api':
@@ -755,6 +774,12 @@ packages:
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.123':
+    resolution: {integrity: sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==}
+
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
 
@@ -888,6 +913,10 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1472,9 +1501,16 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1605,6 +1641,9 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2018,6 +2057,20 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -2097,6 +2150,18 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   openid-client@5.7.1:
     resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
@@ -2668,6 +2733,9 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
@@ -2761,6 +2829,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2858,6 +2929,13 @@ packages:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -2873,6 +2951,9 @@ packages:
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
     engines: {node: '>=12'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3377,6 +3458,15 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 20.19.11
+      form-data: 4.0.4
+
+  '@types/node@18.19.123':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -3542,6 +3632,10 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv@6.12.6:
     dependencies:
@@ -4298,6 +4392,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@1.7.2: {}
+
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -4305,6 +4401,11 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
 
   fraction.js@4.3.7: {}
 
@@ -4451,6 +4552,10 @@ snapshots:
       - supports-color
 
   human-signals@5.0.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -4923,6 +5028,12 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
@@ -4997,6 +5108,21 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@4.104.0(ws@8.18.3)(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.123
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
 
   openid-client@5.7.1:
     dependencies:
@@ -5643,6 +5769,8 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tr46@0.0.3: {}
+
   tr46@3.0.0:
     dependencies:
       punycode: 2.3.1
@@ -5735,6 +5863,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -5829,6 +5959,10 @@ snapshots:
     dependencies:
       xml-name-validator: 4.0.0
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@2.0.0:
@@ -5841,6 +5975,11 @@ snapshots:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "paths": {
       "@acme/db": ["packages/db/src"],
       "@acme/ui": ["packages/ui/src"],
-      "@acme/config": ["packages/config/src"]
+      "@acme/config": ["packages/config/src"],
+      "@acme/ai": ["packages/ai/src"]
     }
   },
   "include": ["apps/**/*", "packages/**/*", "tests/**/*", "e2e/**/*"],


### PR DESCRIPTION
## Summary
- add AI package for embeddings with OpenAI support
- expose semantic search API endpoint
- validate OPENAI_API_KEY env var

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prettier issues in packages/ui)*

------
https://chatgpt.com/codex/tasks/task_e_68acd4bc09588320831c7d37316ea3cd